### PR TITLE
On the fly second derivative

### DIFF
--- a/src/afnet.rs
+++ b/src/afnet.rs
@@ -298,28 +298,6 @@ impl Arm {
         }
     }
 
-    fn update_momenta(
-        &self,
-        momenta: &mut ArmMomenta,
-        step_sizes: &Vec<f64>,
-        // the fraction of a step that will be taken
-        step_size_fraction: f64,
-        x_train: &Array<f64>,
-        y_train: &Array<f64>,
-    ) {
-        let ld_gradient = self.log_density_gradient(x_train, y_train);
-        // update each momentum component individually
-        for index in 0..self.num_layers {
-            momenta.weight_momenta[index] +=
-                step_sizes[index] * step_size_fraction * &ld_gradient.wrt_weights[index];
-            if index == self.num_layers - 1 {
-                break;
-            }
-            momenta.bias_momenta[index] +=
-                step_sizes[index] * step_size_fraction * &ld_gradient.wrt_biases[index];
-        }
-    }
-
     fn uniform_step_sizes(&self, val: f64) -> StepSizes {
         let mut wrt_weights = Vec::with_capacity(self.num_layers);
         let mut wrt_biases = Vec::with_capacity(self.num_layers - 1);

--- a/src/afnet.rs
+++ b/src/afnet.rs
@@ -53,6 +53,48 @@ impl ArmMomenta {
     }
 }
 
+#[derive(Clone)]
+struct StepSizes {
+    wrt_weights: Vec<Array<f64>>,
+    wrt_biases: Vec<Array<f64>>,
+}
+
+impl fmt::Debug for StepSizes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.param_vec())
+    }
+}
+
+impl StepSizes {
+    fn param_vec(&self) -> Vec<f64> {
+        let mut host_vec = Vec::new();
+        host_vec.resize(self.num_params(), 0.);
+        let mut insert_ix: usize = 0;
+        for i in 0..self.wrt_weights.len() {
+            let len = self.wrt_weights[i].elements();
+            self.wrt_weights[i].host(&mut host_vec[insert_ix..insert_ix + len]);
+            insert_ix += len;
+        }
+        for i in 0..self.wrt_biases.len() {
+            let len = self.wrt_biases[i].elements();
+            self.wrt_biases[i].host(&mut host_vec[insert_ix..insert_ix + len]);
+            insert_ix += len;
+        }
+        host_vec
+    }
+
+    fn num_params(&self) -> usize {
+        let mut res: usize = 0;
+        for i in 0..self.wrt_weights.len() {
+            res += self.wrt_weights[i].elements();
+        }
+        for i in 0..self.wrt_biases.len() {
+            res += self.wrt_biases[i].elements();
+        }
+        res
+    }
+}
+
 /// Weights and biases
 #[derive(Clone)]
 struct ArmParams {
@@ -164,8 +206,9 @@ impl Arm {
         step_size: f64,
     ) -> bool {
         let init_params = self.params.clone();
-        let init_rss = self.rss(x_train, y_train);
         // TODO: add heuristic step sizes
+        // for that I will need to keep last rounds gradient, step sizes and momenta
+
         // TODO: add u turn diagnostic for tuning
         let init_momenta = self.sample_momenta();
         let init_neg_hamiltonian = self.neg_hamiltonian(&init_momenta, x_train, y_train);

--- a/src/afnet.rs
+++ b/src/afnet.rs
@@ -56,7 +56,9 @@ impl StepSizes {
 
     // TODO: better to use some dual averaging scheme?
     // TODO: test this!
-    fn update(
+    // TODO: this will almost definitely violate reversibility and therefore detailed balance.
+    // It might still work, but is not guaranteed to?
+    fn update_with_second_derivative(
         &mut self,
         prev_momenta: &ArmMomenta,
         prev_gradients: &ArmLogDensityGradient,


### PR DESCRIPTION
The second derivative part of StepSizes is not tested, but I am merging this anyway, because it uses the StepSizes struct in the momentum and position updates.
I think that using the second derivative udpate after every leapfrog step (or at all really) will violate detailed balance, because the computation of the 2nd deriv uses position information. Intuitively, this should make trajectories non-reversible.
I will instead go for random step sizes from some distribution and apply a threshold on the hamiltonian change to reject trajectories early.